### PR TITLE
Adding translation key for "About"

### DIFF
--- a/birch-message.html
+++ b/birch-message.html
@@ -51,7 +51,7 @@ Example:
             <span>[[contactName]]</span>
           </div>
           <div id="about-section">
-            <p>About</p>
+            <p>[[i18n('about')]]</p>
             <div class="about-data">
               <div hidden="[[_hideAboutDetails]]">[[_documentTitle]]</div>
               <div hidden="[[_hideAboutDetails]]">[[_pageURL]]</div>

--- a/locales/birch-message_en.json
+++ b/locales/birch-message_en.json
@@ -1,6 +1,7 @@
 {
 	"send": "Send",
 	"cancel": "Cancel",
+	"about": "About",
 	"remove": "Remove",
 	"undo": "Undo",
 	"message": "Message",


### PR DESCRIPTION
Why wasn't it there before? No one knows.