### PR TITLE
Removing cedar-dialog as base dialog component; replacing with fs-dialog.

### DIFF
--- a/birch-message.css
+++ b/birch-message.css
@@ -1,6 +1,14 @@
-:host {
-  --cedar-dialog: {
-    max-width: 500px !important;
+#innerDialog {
+  min-width: 445px;
+}
+@media all and (max-width: 550px) {
+  #innerDialog {
+    min-width: 370px;
+  }
+}
+@media all and (max-width: 430px) {
+  #innerDialog {
+    min-width: 82vw;
   }
 }
 #to-section {
@@ -45,8 +53,14 @@
   padding: 14px 0;
 }
 #message-section #textarea {
-  min-height: 130px;
-  max-height: 200px;
+  min-height: 170px;
+  max-height: 220px;
+}
+@media all and (max-width: 550px) {
+  #message-section #textarea {
+    min-height: 120px;
+    max-height: 170px;
+  }
 }
 #message-section .char-count {
   text-align: right;

--- a/birch-message.css
+++ b/birch-message.css
@@ -52,6 +52,11 @@
 #message-section {
   padding: 14px 0;
 }
+@media all and (min-width: 550px) {
+  #message-section {
+    width: 445px;
+  }
+}
 #message-section #textarea {
   min-height: 170px;
   max-height: 220px;

--- a/birch-message.css
+++ b/birch-message.css
@@ -50,12 +50,8 @@
   padding: 14px 0;
 }
 #message-section {
+  width: 100%;
   padding: 14px 0;
-}
-@media all and (min-width: 550px) {
-  #message-section {
-    width: 445px;
-  }
 }
 #message-section #textarea {
   min-height: 170px;
@@ -69,4 +65,12 @@
 }
 #message-section .char-count {
   text-align: right;
+}
+#close-icon {
+  top: 10px;
+  right: 10px;
+  opacity: 0.5;
+  transform: scale(0.7);
+  cursor: pointer;
+  position: absolute;
 }

--- a/birch-message.css
+++ b/birch-message.css
@@ -1,5 +1,7 @@
-#innerDialog {
-  min-width: 445px;
+@media all and (min-width: 550px) {
+  #innerDialog {
+    width: 480px;
+  }
 }
 @media all and (max-width: 550px) {
   #innerDialog {
@@ -50,8 +52,7 @@
   padding: 14px 0;
 }
 #message-section {
-  width: 100%;
-  padding: 14px 0;
+  width: 100%
 }
 #message-section #textarea {
   min-height: 170px;

--- a/birch-message.html
+++ b/birch-message.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../cedar-dialog/cedar-dialog.html">
+<link rel="import" href="../dialog-el/fs-dialog.html">
 <link rel="import" href="../fs-button/fs-button.html">
 <link rel="import" href="../fs-styles/fs-styles.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
@@ -43,14 +43,14 @@ Example:
       body="[[_body]]"
       on-response="_handleResponse"
       on-error="_handleError"></iron-ajax>
-    <cedar-dialog id="dialogBox" modal>
+    <fs-dialog id="dialogBox" modal>
         <h4 header>[[i18n('new_message')]]</h4>
         <div id="innerDialog" content>
           <div id="to-section">
             <p>[[i18n('to')]]</p>
             <span>[[contactName]]</span>
           </div>
-          <div id="about-section">
+          <div id="about-section" hidden="[[disableAbout]]">
             <p>[[i18n('about')]]</p>
             <div class="about-data">
               <div hidden="[[_hideAboutDetails]]">[[_documentTitle]]</div>
@@ -80,7 +80,7 @@ Example:
           <button is='fs-button' type="button" option="minor" on-tap="close">[[i18n('cancel')]]</button>
         </div>
       </div>
-    </cedar-dialog>
+    </fs-dialog>
 
   </template>
 
@@ -101,6 +101,13 @@ Example:
         contactName: {
           type: String,
           value: "Patron"
+        },
+        /**
+         * Don't show the "about" section in the component
+        **/
+        disableAbout: {
+          type: Boolean,
+          value: false
         },
         /**
          * Will be set to true if there is an error in the call for the data.
@@ -139,7 +146,7 @@ Example:
         Method for opening the message dialog.
       **/
       open: function() {
-        this.$.dialogBox.open();
+        this.$.dialogBox.show();
       },
       /**
         Method for closing the message dialog.
@@ -182,9 +189,11 @@ Example:
         this.fire('birch-message-error', e.detail);
       },
       _handleUndo: function(e) {
+        e.detail.sourceEvent.stopPropagation();
         this._hideAboutDetails = false;
       },
       _handleRemove: function(e) {
+        e.detail.sourceEvent.stopPropagation();
         this._hideAboutDetails = true;
       },
       _handleResponse: function(e) {

--- a/birch-message.html
+++ b/birch-message.html
@@ -10,7 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../dialog-el/fs-dialog.html">
-<link rel="import" href="../fs-button/fs-button.html">
+<link rel="import" href="../styles-wc/fs-button/fs-button.html">
+<link rel="import" href="../styles-wc/fs-icon/fs-icon.html">
 <link rel="import" href="../fs-styles/fs-styles.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
@@ -79,6 +80,7 @@ Example:
           <button is='fs-button' id="sendButton" type="button" option="recommended" on-tap="_postMessage" disabled>[[i18n('send')]]</button>
           <button is='fs-button' type="button" option="minor" on-tap="close">[[i18n('cancel')]]</button>
         </div>
+        <fs-icon id="close-icon" icon="close" on-tap="close"></fs-icon>
       </div>
     </fs-dialog>
 

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "^4.0.0"
+    "web-component-tester": "^6.0.0"
   },
   "resolutions": {
     "polymer": "^1.2.0",

--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,10 @@
     "/test/"
   ],
   "dependencies": {
-    "cedar-dialog": "FamilySearchElements/cedar-dialog#adding-dialog",
+    "dialog-el": "fs-webdev/dialog-el",
     "polymer": "Polymer/polymer#^1.2.0",
     "fs-button": "jshcrowthe/fs-button",
-    "fs-styles": "fs-webdev/fs-styles",
+    "fs-styles": "fs-webdev/fs-styles#3.x",
     "iron-ajax": "^1.4.3",
     "wc-i18n": "jshcrowthe/wc-i18n#^2.1.0",
     "oak-i18n-behavior": "FamilySearchElements/oak-i18n-behavior#1.x",
@@ -33,6 +33,8 @@
     "web-component-tester": "^4.0.0"
   },
   "resolutions": {
-    "polymer": "^1.2.0"
+    "polymer": "^1.2.0",
+    "promise-polyfill": "^6.0.1",
+    "fs-styles": "3.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "dialog-el": "fs-webdev/dialog-el#~1.3.0",
     "polymer": "Polymer/polymer#^1.2.0",
-    "fs-button": "jshcrowthe/fs-button",
     "fs-styles": "fs-webdev/fs-styles#3.x",
+    "styles-wc": "git+https://github.com/fs-webdev/styles-wc#~2.1.7",
     "iron-ajax": "^1.4.3",
     "wc-i18n": "jshcrowthe/wc-i18n#^2.1.0",
     "oak-i18n-behavior": "FamilySearchElements/oak-i18n-behavior#1.x",

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "/test/"
   ],
   "dependencies": {
-    "dialog-el": "fs-webdev/dialog-el~1.3.0",
+    "dialog-el": "fs-webdev/dialog-el#~1.3.0",
     "polymer": "Polymer/polymer#^1.2.0",
     "fs-button": "jshcrowthe/fs-button",
     "fs-styles": "fs-webdev/fs-styles#3.x",

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "/test/"
   ],
   "dependencies": {
-    "dialog-el": "fs-webdev/dialog-el",
+    "dialog-el": "fs-webdev/dialog-el~1.3.0",
     "polymer": "Polymer/polymer#^1.2.0",
     "fs-button": "jshcrowthe/fs-button",
     "fs-styles": "fs-webdev/fs-styles#3.x",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-message",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -34,24 +34,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('<birch-message>', function() {
 
         var myEl;
-        var cedarDialog
+        var fsDialog;
 
         setup(function() {
           myEl = fixture('birch-message-fixture');
-          cedarDialog = Polymer.dom(myEl.root).querySelector('#dialogBox');
-          paperDialog = Polymer.dom(Polymer.dom(myEl.root).querySelector('#dialogBox').root).querySelector('#modal');
+          fsDialog = Polymer.dom(myEl.root).querySelector('#dialogBox');
         });
 
-        test('Open and close functions exist and are called', function(done) {
-          var opened = sinon.spy(cedarDialog, 'open');
+        test('Open and close functions exist and are called', function() {
+          var opened = sinon.spy(fsDialog, 'show');
           myEl.open();
           expect(opened.calledOnce).to.be.true;
 
-          var closed = sinon.spy(cedarDialog, 'close');
+          var closed = sinon.spy(fsDialog, 'close');
           myEl.close();
           expect(opened.calledOnce).to.be.true;
-
-          done()
         });
 
         test('Post message success/event', function(done){
@@ -76,7 +73,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           myEl.addEventListener('birch-message-sent', function(e){
             expect(e.detail.response.success).to.be.true;
             expect(handleResponse.calledOnce).to.be.true;
-            expect(paperDialog.opened).to.be.false;
             done();
           });
 
@@ -152,17 +148,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
           myEl._handleResponse(mockE)
-
-          expect(paperDialog.opened).to.be.true;
           expect(windowFunction.calledTwice).to.be.true;
 
         }, 200);
 
         test('Test remove and undo of message about section', function(){
-          myEl._handleUndo();
+          var mockE = {
+            detail: {
+              sourceEvent: {
+                stopPropagation: function(){}
+              } 
+            }
+          }
+          myEl._handleUndo(mockE);
           expect(myEl._hideAboutDetails).to.be.false;
 
-          myEl._handleRemove();
+          myEl._handleRemove(mockE);
           expect(myEl._hideAboutDetails).to.be.true;
         });
 


### PR DESCRIPTION
- Removing `cedar-dialog`, replacing with `fs-dialog` to save weight (saved 161k before vulcanizing/bundling)
- Removing jshcrowthe's  `fs-button` and replaced it with `styles-wc` implementation
- Adding `disableAbout` for removing the about section (recommended, it's tacky)
- Updating unit tests accordingly (100% pass/coverage)